### PR TITLE
Feat/3 login

### DIFF
--- a/app/controllers/api/v0/sessions_controller.rb
+++ b/app/controllers/api/v0/sessions_controller.rb
@@ -1,2 +1,17 @@
 class Api::V0::SessionsController < ApplicationController
+  def create
+    user = User.find_by(email: params[:email])
+
+    if user && user.authenticate(params[:password])
+      render json: { data: { type: 'users', id: user.id.to_s, attributes: { email: user.email, api_key: user.api_key } } }, status: :ok
+    else
+      unauthorized_error
+    end
+  end
+
+  private
+
+  def unauthorized_error
+    render json: { errors: ['Invalid credentials'] }, status: :unauthorized
+  end
 end

--- a/app/controllers/api/v0/sessions_controller.rb
+++ b/app/controllers/api/v0/sessions_controller.rb
@@ -1,0 +1,2 @@
+class Api::V0::SessionsController < ApplicationController
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     namespace :v0 do
       get '/forecast', to: 'forecast#weather_forecast'
       resources :users, only: [:create]
+      resources :sessions, only: [:create]
     end
 
     namespace :v1 do

--- a/spec/requests/api/v0/users_requests/login_spec.rb
+++ b/spec/requests/api/v0/users_requests/login_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Create users, email, password ", type: :request do
       errors = JSON.parse(response.body, symbolize_names: true)
       expect(errors).to have_key(:errors)
       expect(errors[:errors]).to be_an(Array)
-      expect(errors[:errors].first[:detail]).to include("Invalid credentials")
+      expect(errors[:errors].first).to include('Invalid credentials')
     end
 
     it 'returns error for invalid credentials, wrong email, same message for wrong email or password' do
@@ -48,7 +48,7 @@ RSpec.describe "Create users, email, password ", type: :request do
       errors = JSON.parse(response.body, symbolize_names: true)
       expect(errors).to have_key(:errors)
       expect(errors[:errors]).to be_an(Array)
-      expect(errors[:errors].first[:detail]).to include("Invalid credentials")
+      expect(errors[:errors].first).to include('Invalid credentials')
     end
   end
 end

--- a/spec/requests/api/v0/users_requests/login_spec.rb
+++ b/spec/requests/api/v0/users_requests/login_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe "Create users, email, password ", type: :request do
+  describe "POST /api/v0/sessions" do
+    it 'valid credentials are sent, then has response' do
+      user = create(:user, email: 'test@email.com', password: 'password', password_confirmation: 'password')
+      valid_session_params = { email: user.email, password: user.password }
+
+      post '/api/v0/sessions', params: valid_session_params.to_json, headers: { 'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json' }
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      data = JSON.parse(response.body, symbolize_names: true)
+      expect(data).to have_key(:data)
+      expect(data[:data]).to have_key(:type)
+      expect(data[:data][:type]).to eq('users')
+      expect(data[:data]).to have_key(:id)
+      expect(data[:data][:id]).to be_a(String)
+      expect(data[:data]).to have_key(:attributes)
+      expect(data[:data][:attributes]).to have_key(:email)
+      expect(data[:data][:attributes][:email]).to eq('test@email.com')
+      expect(data[:data][:attributes]).to have_key(:api_key)
+      expect(data[:data][:attributes][:api_key]).to be_a(String)
+    end
+
+    it 'returns error for invalid credentials, wrong email, same message for wrong email or password' do
+      user = create(:user, email: 'test@email.com', password: 'password', password_confirmation: 'password')
+      invalid_session_params = { email: 'wrong@email.com', password: user.password }
+      
+      post '/api/v0/sessions', params: invalid_session_params.to_json, headers: { 'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json' }
+      expect(response).not_to be_successful
+      expect(response.status).to eq(401)
+
+      errors = JSON.parse(response.body, symbolize_names: true)
+      expect(errors).to have_key(:errors)
+      expect(errors[:errors]).to be_an(Array)
+      expect(errors[:errors].first[:detail]).to include("Invalid credentials")
+    end
+
+    it 'returns error for invalid credentials, wrong email, same message for wrong email or password' do
+      user = create(:user, email: 'test@email.com', password: 'password', password_confirmation: 'password')
+      invalid_session_params = { email: user.email, password: 'WrongPassword'}
+      
+      post '/api/v0/sessions', params: invalid_session_params.to_json, headers: { 'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json' }
+      expect(response).not_to be_successful
+      expect(response.status).to eq(401)
+
+      errors = JSON.parse(response.body, symbolize_names: true)
+      expect(errors).to have_key(:errors)
+      expect(errors[:errors]).to be_an(Array)
+      expect(errors[:errors].first[:detail]).to include("Invalid credentials")
+    end
+  end
+end


### PR DESCRIPTION
Add login session endpoint `POST /api/v0/sessions`

Post with email and password, response with email and api key

FUTURE: Maybe refactor out the json serializing into a `Serializer` class, I did it in the controller, so I did not have to test.